### PR TITLE
Allow dirty publishing

### DIFF
--- a/src/external/cargo.rs
+++ b/src/external/cargo.rs
@@ -42,6 +42,7 @@ pub fn publish_crate(root: &Path, package: &str) -> anyhow::Result<()> {
         .arg("publish")
         .arg("-p")
         .arg(package)
+        .arg("--allow-dirty")
         .status()?;
 
     Ok(())


### PR DESCRIPTION
The subpub will remove all `[dev-dependencies]` from the crates that will soon get published.
This will modify the substrate repository in accordance with the change, leaving some uncommited Cargo.toml files.

The `cargo publish -p [package]` command was used in the past.
However, this command no longer works for git-dirty repositories.
To mitigate this change, add the `--allow-dirty` argument to the cargo publish.


// @paritytech/subxt-team 